### PR TITLE
Add PacketEvents option, config improvements, and version bump to 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ecb.ajneb97</groupId>
     <artifactId>EasyCommandBlocker</artifactId>
-    <version>1.14.3</version>
+    <version>1.15.0</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -34,6 +34,14 @@
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+            <id>codemc-releases</id>
+            <url>https://repo.codemc.io/repository/maven-releases/</url>
+        </repository>
+        <repository>
+            <id>codemc-snapshots</id>
+            <url>https://repo.codemc.io/repository/maven-snapshots/</url>
         </repository>
     </repositories>
 
@@ -69,15 +77,23 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>me.carleslc.Simple-YAML</groupId>
+            <groupId>com.github.Carleslc.Simple-YAML</groupId>
             <artifactId>Simple-Yaml</artifactId>
-            <version>1.8</version>
+            <version>1.8.4</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.30</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.retrooper</groupId>
+            <artifactId>packetevents-spigot</artifactId>
+            <version>2.9.3</version>
+            <scope>provided</scope>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/src/main/java/ecb/ajneb97/spigot/listeners/PacketEventsListener.java
+++ b/src/main/java/ecb/ajneb97/spigot/listeners/PacketEventsListener.java
@@ -1,0 +1,116 @@
+package ecb.ajneb97.spigot.listeners;
+
+import com.comphenix.protocol.reflect.StructureModifier;
+import com.github.retrooper.packetevents.event.PacketListenerAbstract;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientTabComplete;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTabComplete;
+import ecb.ajneb97.core.managers.CommandsManager;
+import ecb.ajneb97.spigot.EasyCommandBlocker;
+import ecb.ajneb97.spigot.utils.OtherUtils;
+import org.bukkit.entity.Player;
+
+import java.util.*;
+
+public class PacketEventsListener extends PacketListenerAbstract {
+    private EasyCommandBlocker plugin;
+    private Map<UUID, String> commandsWaiting = new HashMap<>();
+
+    public PacketEventsListener(PacketListenerPriority priority, EasyCommandBlocker plugin) {
+        super(priority);
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent e) {
+        if (e.getPacketType() != PacketType.Play.Client.TAB_COMPLETE) return;
+        if (e.isCancelled()) return;
+
+        Player player = e.getPlayer();
+
+        if((player.isOp() && plugin.getConfigManager().getConfig().getBoolean("can_ops_bypass")) || player.hasPermission("easycommandblocker.bypass.tab")){
+            return;
+        }
+
+        WrapperPlayClientTabComplete wrapper = new WrapperPlayClientTabComplete(e);
+        String text = wrapper.getText();
+
+        if (text.isEmpty()) {
+            return;
+        }
+
+        boolean playerIsLegacy = plugin.getViaVersionManager().playerIsLegacy(player);
+        if(OtherUtils.serverIsLegacy()){
+            if(playerIsLegacy){
+                commandsWaiting.put(player.getUniqueId(),text);
+            }else{
+                e.setCancelled(true);
+            }
+        }else{
+            if(playerIsLegacy){
+                e.setCancelled(true);
+            }
+        }
+    }
+
+    @Override
+    public void onPacketSend(PacketSendEvent e) {
+        if (e.getPacketType() != PacketType.Play.Server.TAB_COMPLETE) return;
+
+        Player player = e.getPlayer();
+        boolean playerIsLegacy = plugin.getViaVersionManager().playerIsLegacy(player);
+        if(!playerIsLegacy || !OtherUtils.serverIsLegacy()){
+            return;
+        }
+        if((player.isOp() && plugin.getConfigManager().getConfig().getBoolean("can_ops_bypass")) || player.hasPermission("easycommandblocker.bypass.tab")){
+            return;
+        }
+
+        WrapperPlayServerTabComplete wrapper = new WrapperPlayServerTabComplete(e);
+        List<String> newSuggestions = new ArrayList<String>();
+
+        String waitCommand = commandsWaiting.get(player.getUniqueId());
+        commandsWaiting.remove(player.getUniqueId());
+        if(waitCommand == null){
+            //Empty completions
+            e.setCancelled(true);
+            return;
+        }
+        if(!waitCommand.startsWith("/")){
+            //Send username completions
+            return;
+        }
+
+        CommandsManager commandsManager = plugin.getCommandsManager();
+        List<String> commands = commandsManager.getTabCommands(OtherUtils.getPlayerPermissionsList(player));
+        if(commands == null){
+            return;
+        }
+
+        boolean isArgument = false;
+        if(waitCommand.contains(" ")){
+            waitCommand = waitCommand.split(" ")[0];
+            isArgument = true;
+        }
+
+        for(String command : commands){
+            command = command.split(" ")[0];
+            if(!newSuggestions.contains(command) && command.startsWith(waitCommand)){
+                if(isArgument){
+                    return;
+                }
+                newSuggestions.add(command);
+            }
+        }
+
+        List<WrapperPlayServerTabComplete.CommandMatch> commandMatches = new ArrayList<>();
+        for (String suggestion : newSuggestions) {
+            commandMatches.add(new WrapperPlayServerTabComplete.CommandMatch(suggestion, null));
+        }
+        wrapper.setCommandMatches(commandMatches);
+
+    }
+}

--- a/src/main/java/ecb/ajneb97/spigot/listeners/PlayerListener.java
+++ b/src/main/java/ecb/ajneb97/spigot/listeners/PlayerListener.java
@@ -26,7 +26,7 @@ public class PlayerListener implements Listener {
     public void executeCommand(PlayerCommandPreprocessEvent event){
         Player player = event.getPlayer();
         String command = event.getMessage();
-        if(player.isOp() || player.hasPermission("easycommandblocker.bypass.commands")){
+        if((player.isOp() && plugin.getConfigManager().getConfig().getBoolean("can_ops_bypass")) || player.hasPermission("easycommandblocker.bypass.commands")){
             return;
         }
 

--- a/src/main/java/ecb/ajneb97/spigot/listeners/PlayerListenerNew.java
+++ b/src/main/java/ecb/ajneb97/spigot/listeners/PlayerListenerNew.java
@@ -21,7 +21,7 @@ public class PlayerListenerNew implements Listener {
     public void onCommandSend(PlayerCommandSendEvent event){
         Player player = event.getPlayer();
 
-        if(player.isOp() || player.hasPermission("easycommandblocker.bypass.tab")){
+        if((player.isOp() && plugin.getConfigManager().getConfig().getBoolean("can_ops_bypass")) || player.hasPermission("easycommandblocker.bypass.tab")){
             return;
         }
         CommandsManager commandsManager = plugin.getCommandsManager();

--- a/src/main/java/ecb/ajneb97/spigot/managers/PacketEventsManager.java
+++ b/src/main/java/ecb/ajneb97/spigot/managers/PacketEventsManager.java
@@ -1,0 +1,32 @@
+package ecb.ajneb97.spigot.managers;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListenerCommon;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import ecb.ajneb97.spigot.EasyCommandBlocker;
+import ecb.ajneb97.spigot.listeners.PacketEventsListener;
+import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder;
+import org.bukkit.Bukkit;
+
+public class PacketEventsManager {
+    private EasyCommandBlocker plugin;
+
+    public PacketEventsManager(EasyCommandBlocker plugin){
+        this.plugin = plugin;
+
+        if(Bukkit.getServer().getPluginManager().getPlugin("packetevents") != null
+                && Bukkit.getServer().getPluginManager().getPlugin("packetevents").isEnabled()) {
+            PacketEvents.setAPI(SpigotPacketEventsBuilder.build(plugin));
+            PacketEvents.getAPI().load();
+        }
+    }
+
+    public void register() {
+        PacketEvents.getAPI().getEventManager().registerListener(new PacketEventsListener(PacketListenerPriority.HIGHEST, plugin));
+    }
+
+    public void terminate() {
+
+        PacketEvents.getAPI().terminate();
+    }
+}

--- a/src/main/java/ecb/ajneb97/spigot/managers/ProtocolLibManager.java
+++ b/src/main/java/ecb/ajneb97/spigot/managers/ProtocolLibManager.java
@@ -40,6 +40,10 @@ public class ProtocolLibManager {
         return enabled;
     }
 
+    public void unregisterAdapters() {
+        ProtocolLibrary.getProtocolManager().removePacketListeners(plugin);
+    }
+
     public PacketAdapter getTabClientAdapter(PacketType type) {
         return new PacketAdapter(plugin, ListenerPriority.HIGHEST, type) {
             @Override
@@ -51,7 +55,7 @@ public class ProtocolLibManager {
                 if(event.isCancelled()){
                     return;
                 }
-                if(player.isOp() || player.hasPermission("easycommandblocker.bypass.tab")){
+                if((player.isOp() && pluginE.getConfigManager().getConfig().getBoolean("can_ops_bypass")) || player.hasPermission("easycommandblocker.bypass.tab")){
                     return;
                 }
                 String message = (packet.getSpecificModifier(String.class).read(0));
@@ -87,7 +91,7 @@ public class ProtocolLibManager {
                 if(!playerIsLegacy || !OtherUtils.serverIsLegacy()){
                     return;
                 }
-                if(player.isOp() || player.hasPermission("easycommandblocker.bypass.tab")){
+                if((player.isOp() && pluginE.getConfigManager().getConfig().getBoolean("can_ops_bypass")) || player.hasPermission("easycommandblocker.bypass.tab")){
                     return;
                 }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,9 @@ blocked_command_default_actions:
 use_commands_as_whitelist: false
 is_network: false
 update_notify: true
+use_packet_events_instead_of_protocol_lib: false
+# This only works if you remove * permission from all players using your permission plugin
+can_ops_bypass: true
 commands:
   - "/?"
   - "/bukkit:?"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${project.version}
 name: EasyCommandBlocker
 api-version: 1.13
 softdepend: [ViaVersion]
-depend: [ProtocolLib]
+depend: [ProtocolLib,packetevents]
 author: Ajneb97
 
 commands:


### PR DESCRIPTION
- Bumped plugin version from `1.14.3` to `1.15.0`
- Added support for `PacketEvents` as an alternative to `ProtocolLib`
- Adds 2 new config option:
  -  use_packet_events_instead_of_protocol_lib: switch between PacketEvents and ProtocolLib
  -  can_ops_bypass: allows enabling or disabling OP players ability to bypass restrictions. **_This only works if you remove * permission from all players using a permission plugin_**